### PR TITLE
Disable webpack warnings

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -286,6 +286,17 @@ module.exports = function(options) {
       module: false,
       clearImmediate: false,
       setImmediate: false
-    }
+    },
+    /**
+     * Use stats to turn off verbose output
+     */
+    stats: {
+      /**
+       * Filter warnings to be shown
+       *
+       * See: https://github.com/angular/angular/issues/21560
+       */
+      warningsFilter: /System.import/,
+    },
   };
 };

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -133,6 +133,17 @@ module.exports = function(options) {
         ignored: /node_modules/
       },
       /**
+       * Use stats to turn off verbose output
+       */
+      stats: {
+        /**
+         * Filter warnings to be shown
+         *
+         * See: https://github.com/angular/angular/issues/21560
+         */
+        warningsFilter: /System.import/,
+      },
+      /**
        * Here you can access the Express app object and add your own custom middleware to it.
        *
        * See: https://webpack.js.org/configuration/dev-server/


### PR DESCRIPTION
Disable webpack warnings:

```
WARNING in ./node_modules/@angular/core/fesm5/core.js 4996:15-36
System.import() is deprecated and will be removed soon. Use import() instead.
For more info visit https://webpack.js.org/guides/code-splitting/
 @ ./src/app/app.component.ts 7:13-37
 @ ./src/main.browser.ts
 @ multi (webpack)-dev-server/client?http://localhost:3000 ./src/main.browser.ts

WARNING in ./node_modules/@angular/core/fesm5/core.js 5008:15-102
System.import() is deprecated and will be removed soon. Use import() instead.
For more info visit https://webpack.js.org/guides/code-splitting/
 @ ./src/app/app.component.ts 7:13-37
 @ ./src/main.browser.ts
 @ multi (webpack)-dev-server/client?http://localhost:3000 ./src/main.browser.ts
```